### PR TITLE
Copy SVG utilities from cs61a-apps

### DIFF
--- a/python/svg.py
+++ b/python/svg.py
@@ -1,0 +1,153 @@
+# MIT License
+#
+# Copyright (c) 2021 CS 61A
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+class SVGRect:
+    def __init__(self, x, y, width, height, stroke, fill):
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+        self.stroke = stroke
+        self.fill = fill
+
+    def __str__(self):
+        return """<rect x="{0}" y="{1}" width="{2}" height="{3}" stroke="{4}" fill="{5}" />""".format(
+            self.x, self.y, self.width, self.height, self.stroke, self.fill
+        )
+
+
+class SVGCircle:
+    def __init__(self, x, y, radius, stroke, fill):
+        self.x = x
+        self.y = y
+        self.radius = radius
+        self.stroke = stroke
+        self.fill = fill
+
+    def __str__(self):
+        return (
+            """<circle cx="{0}" cy="{1}" r="{2}" stroke="{3}" fill="{4}" />""".format(
+                self.x, self.y, self.radius, self.stroke, self.fill
+            )
+        )
+
+
+class SVGLine:
+    def __init__(self, x1, y1, x2, y2, stroke):
+        self.x1 = x1
+        self.y1 = y1
+        self.x2 = x2
+        self.y2 = y2
+        self.stroke = stroke
+
+    def __str__(self):
+        return """<line x1="{0}" y1="{1}" x2="{2}" y2="{3}" stroke="{4}" />""".format(
+            self.x1, self.y1, self.x2, self.y2, self.stroke
+        )
+
+
+class SVGPolygon:
+    def __init__(self, points, stroke, fill):
+        self.points = points  # list of lists
+        self.stroke = stroke
+        self.fill = fill
+
+    def __str__(self):
+        points_str = " ".join(",".join(map(str, point)) for point in self.points)
+        return """<polygon points="{0}" stroke="{1}" fill="{2}"/>""".format(
+            points_str, self.stroke, self.fill
+        )
+
+
+class SVGText:
+    def __init__(self, x, y, text, stroke, fill, font_size, font_family):
+        self.x = x
+        self.y = y
+        self.text = text
+        self.stroke = stroke
+        self.fill = fill
+        self.font_size = font_size
+        self.font_family = font_family
+
+    def __str__(self):
+        return """<text x="{0}" y="{1}" stroke="{2}" fill="{3}" font-size="{4}" font-family="{5}">{6}</text>""".format(
+            self.x,
+            self.y,
+            self.stroke,
+            self.fill,
+            self.font_size,
+            self.font_family,
+            self.text,
+        )
+
+
+class SVGGraphic:
+    def __init__(self, width, height):
+        self.width = width
+        self.height = height
+        self.shapes = []
+
+    def draw_rect(self, x, y, width, height, stroke, fill):
+        self.shapes.append(SVGRect(x, y, width, height, stroke, fill))
+
+    def draw_circle(self, x, y, radius, stroke, fill):
+        self.shapes.append(SVGCircle(x, y, radius, stroke, fill))
+
+    def draw_line(self, x1, y1, x2, y2, stroke):
+        self.shapes.append(SVGLine(x1, y1, x2, y2, stroke))
+
+    def draw_polygon(self, points, stroke, fill):
+        self.shapes.append(SVGPolygon(points, stroke, fill))
+
+    def write_text(self, x, y, text, stroke, fill, font_size, font_family):
+        self.shapes.append(SVGText(x, y, text, stroke, fill, font_size, font_family))
+
+    def __str__(self):
+        shapes = "".join(str(shape) for shape in self.shapes)
+        return """<svg width="{0}" height="{1}" xmlns="http://www.w3.org/2000/svg">{2}</svg>""".format(
+            self.width, self.height, shapes
+        )
+
+
+def create_graphic(width, height):
+    return SVGGraphic(width, height)
+
+
+def draw_rect(graphic, x, y, width, height, stroke="black", fill="black"):
+    graphic.draw_rect(x, y, width, height, stroke, fill)
+
+
+def draw_circle(graphic, x, y, radius, stroke="black", fill="black"):
+    graphic.draw_circle(x, y, radius, stroke, fill)
+
+
+def draw_line(graphic, x1, y1, x2, y2, stroke="black"):
+    graphic.draw_line(x1, y1, x2, y2, stroke)
+
+
+def draw_triangle(graphic, x1, y1, x2, y2, x3, y3, stroke="black", fill="black"):
+    graphic.draw_polygon([[x1, y1], [x2, y2], [x3, y3]], stroke, fill)
+
+
+def write_text(
+    graphic,
+    x,
+    y,
+    text,
+    stroke="black",
+    fill="black",
+    font_size="medium",
+    font_family="serif",
+):
+    graphic.write_text(x, y, text, stroke, fill, font_size, font_family)

--- a/python/svg.py
+++ b/python/svg.py
@@ -12,6 +12,7 @@
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
 
+
 class SVGRect:
     def __init__(self, x, y, width, height, stroke, fill):
         self.x = x
@@ -98,19 +99,28 @@ class SVGGraphic:
         self.height = height
         self.shapes = []
 
-    def draw_rect(self, x, y, width, height, stroke, fill):
+    def draw_rect(self, x, y, width, height, stroke="black", fill="black"):
         self.shapes.append(SVGRect(x, y, width, height, stroke, fill))
 
-    def draw_circle(self, x, y, radius, stroke, fill):
+    def draw_circle(self, x, y, radius, stroke="black", fill="black"):
         self.shapes.append(SVGCircle(x, y, radius, stroke, fill))
 
-    def draw_line(self, x1, y1, x2, y2, stroke):
+    def draw_line(self, x1, y1, x2, y2, stroke="black"):
         self.shapes.append(SVGLine(x1, y1, x2, y2, stroke))
 
     def draw_polygon(self, points, stroke, fill):
         self.shapes.append(SVGPolygon(points, stroke, fill))
 
-    def write_text(self, x, y, text, stroke, fill, font_size, font_family):
+    def write_text(
+        self,
+        x,
+        y,
+        text,
+        stroke="black",
+        fill="black",
+        font_size="medium",
+        font_family="serif",
+    ):
         self.shapes.append(SVGText(x, y, text, stroke, fill, font_size, font_family))
 
     def __str__(self):
@@ -120,34 +130,5 @@ class SVGGraphic:
         )
 
 
-def create_graphic(width, height):
-    return SVGGraphic(width, height)
-
-
-def draw_rect(graphic, x, y, width, height, stroke="black", fill="black"):
-    graphic.draw_rect(x, y, width, height, stroke, fill)
-
-
-def draw_circle(graphic, x, y, radius, stroke="black", fill="black"):
-    graphic.draw_circle(x, y, radius, stroke, fill)
-
-
-def draw_line(graphic, x1, y1, x2, y2, stroke="black"):
-    graphic.draw_line(x1, y1, x2, y2, stroke)
-
-
 def draw_triangle(graphic, x1, y1, x2, y2, x3, y3, stroke="black", fill="black"):
     graphic.draw_polygon([[x1, y1], [x2, y2], [x3, y3]], stroke, fill)
-
-
-def write_text(
-    graphic,
-    x,
-    y,
-    text,
-    stroke="black",
-    fill="black",
-    font_size="medium",
-    font_family="serif",
-):
-    graphic.write_text(x, y, text, stroke, fill, font_size, font_family)

--- a/python/svg_test.py
+++ b/python/svg_test.py
@@ -22,37 +22,37 @@ class TestSVG(unittest.TestCase):
         self.assertTrue(str.find(substr) > -1, "%s does not contain %s" % (str, substr))
 
     def test_create_graphic(self):
-        graphic = svg.create_graphic(200, 300)
+        graphic = svg.SVGGraphic(200, 300)
         self.assertEqual(
             str(graphic),
             """<svg width="200" height="300" xmlns="http://www.w3.org/2000/svg"></svg>""",
         )
 
     def test_draw_rect(self):
-        graphic = svg.create_graphic(200, 300)
-        svg.draw_rect(graphic, 10, 20, 30, 40)
+        graphic = svg.SVGGraphic(200, 300)
+        graphic.draw_rect(10, 20, 30, 40)
         self.assert_contains_str(
             str(graphic),
             """<rect x="10" y="20" width="30" height="40" stroke="black" fill="black" />""",
         )
 
     def test_draw_circle(self):
-        graphic = svg.create_graphic(200, 300)
-        svg.draw_circle(graphic, 10, 20, 30)
+        graphic = svg.SVGGraphic(200, 300)
+        graphic.draw_circle(10, 20, 30)
         self.assert_contains_str(
             str(graphic),
             """<circle cx="10" cy="20" r="30" stroke="black" fill="black" />""",
         )
 
     def test_draw_line(self):
-        graphic = svg.create_graphic(200, 300)
-        svg.draw_line(graphic, 10, 20, 30, 40)
+        graphic = svg.SVGGraphic(200, 300)
+        graphic.draw_line(10, 20, 30, 40)
         self.assert_contains_str(
             str(graphic), """<line x1="10" y1="20" x2="30" y2="40" stroke="black" />"""
         )
 
     def test_draw_triangle(self):
-        graphic = svg.create_graphic(200, 300)
+        graphic = svg.SVGGraphic(200, 300)
         svg.draw_triangle(graphic, 10, 20, 15, 150, 150, 150)
         self.assert_contains_str(
             str(graphic),
@@ -60,17 +60,17 @@ class TestSVG(unittest.TestCase):
         )
 
     def test_write_text(self):
-        graphic = svg.create_graphic(200, 300)
-        svg.write_text(graphic, 10, 20, "Turn over")
+        graphic = svg.SVGGraphic(200, 300)
+        graphic.write_text(10, 20, "Turn over")
         self.assert_contains_str(
             str(graphic),
             """<text x="10" y="20" stroke="black" fill="black" font-size="medium" font-family="serif">Turn over</text>""",
         )
 
     def test_write_text_font(self):
-        graphic = svg.create_graphic(200, 300)
-        svg.write_text(
-            graphic, 10, 20, "Turn over", font_size="20", font_family="sans-serif"
+        graphic = svg.SVGGraphic(200, 300)
+        graphic.write_text(
+            10, 20, "Turn over", font_size="20", font_family="sans-serif"
         )
         self.assert_contains_str(
             str(graphic),
@@ -78,8 +78,8 @@ class TestSVG(unittest.TestCase):
         )
 
     def test_stroke_fill(self):
-        graphic = svg.create_graphic(200, 300)
-        svg.draw_rect(graphic, 10, 20, 30, 40, "pink", "blue")
+        graphic = svg.SVGGraphic(200, 300)
+        graphic.draw_rect(10, 20, 30, 40, "pink", "blue")
         self.assert_contains_str(
             str(graphic),
             """<rect x="10" y="20" width="30" height="40" stroke="pink" fill="blue" />""",

--- a/python/svg_test.py
+++ b/python/svg_test.py
@@ -1,0 +1,90 @@
+# MIT License
+#
+# Copyright (c) 2021 CS 61A
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+import unittest
+
+import svg
+
+
+class TestSVG(unittest.TestCase):
+    def assert_contains_str(self, str, substr):
+        self.assertTrue(str.find(substr) > -1, "%s does not contain %s" % (str, substr))
+
+    def test_create_graphic(self):
+        graphic = svg.create_graphic(200, 300)
+        self.assertEqual(
+            str(graphic),
+            """<svg width="200" height="300" xmlns="http://www.w3.org/2000/svg"></svg>""",
+        )
+
+    def test_draw_rect(self):
+        graphic = svg.create_graphic(200, 300)
+        svg.draw_rect(graphic, 10, 20, 30, 40)
+        self.assert_contains_str(
+            str(graphic),
+            """<rect x="10" y="20" width="30" height="40" stroke="black" fill="black" />""",
+        )
+
+    def test_draw_circle(self):
+        graphic = svg.create_graphic(200, 300)
+        svg.draw_circle(graphic, 10, 20, 30)
+        self.assert_contains_str(
+            str(graphic),
+            """<circle cx="10" cy="20" r="30" stroke="black" fill="black" />""",
+        )
+
+    def test_draw_line(self):
+        graphic = svg.create_graphic(200, 300)
+        svg.draw_line(graphic, 10, 20, 30, 40)
+        self.assert_contains_str(
+            str(graphic), """<line x1="10" y1="20" x2="30" y2="40" stroke="black" />"""
+        )
+
+    def test_draw_triangle(self):
+        graphic = svg.create_graphic(200, 300)
+        svg.draw_triangle(graphic, 10, 20, 15, 150, 150, 150)
+        self.assert_contains_str(
+            str(graphic),
+            """<polygon points="10,20 15,150 150,150" stroke="black" fill="black"/>""",
+        )
+
+    def test_write_text(self):
+        graphic = svg.create_graphic(200, 300)
+        svg.write_text(graphic, 10, 20, "Turn over")
+        self.assert_contains_str(
+            str(graphic),
+            """<text x="10" y="20" stroke="black" fill="black" font-size="medium" font-family="serif">Turn over</text>""",
+        )
+
+    def test_write_text_font(self):
+        graphic = svg.create_graphic(200, 300)
+        svg.write_text(
+            graphic, 10, 20, "Turn over", font_size="20", font_family="sans-serif"
+        )
+        self.assert_contains_str(
+            str(graphic),
+            """<text x="10" y="20" stroke="black" fill="black" font-size="20" font-family="sans-serif">Turn over</text>""",
+        )
+
+    def test_stroke_fill(self):
+        graphic = svg.create_graphic(200, 300)
+        svg.draw_rect(graphic, 10, 20, 30, 40, "pink", "blue")
+        self.assert_contains_str(
+            str(graphic),
+            """<rect x="10" y="20" width="30" height="40" stroke="pink" fill="blue" />""",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Copied from https://github.com/Cal-CS-61A-Staff/cs61a-apps/blob/master/gui_files/svg.py and https://github.com/Cal-CS-61A-Staff/cs61a-apps/blob/master/gui_files/svg_test.py, both under MIT license.

Checks pass with `make check`, verified that `svg_test.py` is actually being run.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #10
* #9
* #8
* __->__ #1

